### PR TITLE
feat: add rnaseqc_gtf_collapse.cwl (stranded + unstranded)

### DIFF
--- a/tools/rnaseqc_gtf_collapse.cwl
+++ b/tools/rnaseqc_gtf_collapse.cwl
@@ -1,0 +1,67 @@
+cwlVersion: v1.2
+class: CommandLineTool
+id: rnaseqc_gtf_collapse
+label: "Collapse GTF for RNA-SeQC (GTEx script, stranded & unstranded)"
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: pgc-images.sbgenomics.com/d3b-bixu/toolkit_python:3.0.0
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+
+baseCommand: [bash, -lc]
+
+inputs:
+  gtf:
+    type: File
+    doc: "Input GTF (GENCODE recommended; matching your genome)"
+  out_name_unstranded:
+    type: string
+    doc: "Output filename for unstranded collapsed GTF"
+  out_name_stranded:
+    type: string
+    doc: "Output filename for stranded collapsed GTF"
+
+arguments:
+  - position: 1
+    valueFrom: |
+      set -euo pipefail
+      export PIP_ROOT_USER_ACTION=ignore
+
+      # Install deps
+      python3 -m pip -q install --no-cache-dir numpy pandas bx-python >/dev/null
+
+      # Fetch collapse_annotation.py 
+      python3 - <<'PY'
+      import os, shlex, subprocess, urllib.request
+
+      gtf      = r"$(inputs.gtf.path)"
+      out_un   = r"$(inputs.out_name_unstranded)"
+      out_str  = r"$(inputs.out_name_stranded)"
+
+      url = "https://raw.githubusercontent.com/broadinstitute/gtex-pipeline/master/gene_model/collapse_annotation.py"
+      urllib.request.urlretrieve(url, "collapse_annotation.py")
+
+      # Unstranded
+      cmd_un = ["python3", "collapse_annotation.py", gtf, "collapsed_un.gtf"]
+      print("Running:", " ".join(shlex.quote(c) for c in cmd_un), flush=True)
+      subprocess.check_call(cmd_un)
+      os.replace("collapsed_un.gtf", out_un)
+
+      # Stranded
+      cmd_str = ["python3", "collapse_annotation.py", "--stranded", gtf, "collapsed_str.gtf"]
+      print("Running:", " ".join(shlex.quote(c) for c in cmd_str), flush=True)
+      subprocess.check_call(cmd_str)
+      os.replace("collapsed_str.gtf", out_str)
+      PY
+
+outputs:
+  out_gtf_unstranded:
+    type: File
+    outputBinding:
+      glob: $(inputs.out_name_unstranded)
+  out_gtf_stranded:
+    type: File
+    outputBinding:
+      glob: $(inputs.out_name_stranded)
+


### PR DESCRIPTION
<!--Pull Request Template-->

## Description
Adds a new CWL tool rnaseqc_gtf_collapse.cwl that wraps the GTEx collapse_annotation.py script to generate both unstranded and stranded collapsed GTF files from a GENCODE annotation.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

https://cavatica.sbgenomics.com/u/ababaei/mouse-rna-seq-ref/tasks/36c3d987-f7c3-4873-a311-c6cddf40071c/

**Test Configuration**:
* Environment: `Cavatica CWL runner, Docker image pgc-images.sbgenomics.com/d3b-bixu/toolkit_python:3.0.0`
* Test files: `gencode.vM31.annotation.gtf`

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have committed any related changes to the PR
