### PR TITLE
Feature/as/optional fusion

### DIFF
--- a/workflow/fusion_wf.cwl
+++ b/workflow/fusion_wf.cwl
@@ -1,0 +1,104 @@
+cwlVersion: v1.2
+class: Workflow
+id: fusion-wf
+label: Fusion Workflow
+doc: |
+  # Fusion Workflow
+
+  This workflow is a sub workflow for calling RNA fusions. For full documentation on usage, inputs, outputs, and defaults please see doc section of Kids First DRC RNAseq Workflow.
+
+requirements:
+- class: ScatterFeatureRequirement
+- class: MultipleInputFeatureRequirement
+- class: SubworkflowFeatureRequirement
+- class: InlineJavascriptRequirement
+- class: StepInputExpressionRequirement
+inputs:
+  reference_fasta: {type: 'File', doc: "GRCh38.primary_assembly.genome.fa", "sbg:suggestedValue": {class: File, path: 5f500135e4b0370371c051b4,
+      name: GRCh38.primary_assembly.genome.fa, secondaryFiles: [{class: File, path: 62866da14d85bc2e02ba52db, name: GRCh38.primary_assembly.genome.fa.fai}]},
+    secondaryFiles: ['.fai']}
+  output_basename: {type: 'string?', doc: "String to use as basename for outputs. Will use read1 file basename if null"}
+  gtf_anno: {type: 'File', doc: "General transfer format (gtf) file with gene models corresponding to fasta reference", "sbg:suggestedValue": {
+      class: File, path: 62853e7ad63f7c6d8d7ae5a4, name: gencode.v39.primary_assembly.annotation.gtf}}
+  genome_untar_path: {type: 'string?', doc: "This is what the path will be when genome_tar is unpackaged", default: "GRCh38_v39_CTAT_lib_Mar242022.CUSTOM"}
+  arriba_memory: {type: 'int?', doc: "Mem intensive tool. Set in GB", default: 64}
+  FusionGenome: {type: 'File', doc: "STAR-Fusion CTAT Genome lib", "sbg:suggestedValue": {class: File, path: 62853e7ad63f7c6d8d7ae5a8,
+      name: GRCh38_v39_CTAT_lib_Mar242022.CUSTOM.tar.gz}}
+  compress_chimeric_junction: {type: 'boolean?', default: true, doc: 'If part of a workflow, recommend compressing this file as final
+      output'}
+  rsem_expr_file: {type: 'File'}
+  annofuse_col_num: {type: 'int?', doc: "0-based column number in file of fusion name.", default: 30}
+  fusion_annotator_ref: {type: 'File', doc: "Tar ball with fusion_annot_lib.idx and blast_pairs.idx from STAR-Fusion CTAT Genome lib.
+      Can be same as FusionGenome, but only two files needed from that package", "sbg:suggestedValue": {class: 'File', path: '63cff818facdd82011c8d6fe',
+      name: 'GRCh38_v39_fusion_annot_custom.tar.gz'}}
+  sample_name: {type: 'string'}
+  genome_aligned_bam: {type: 'File', secondaryFiles: [.bai]}
+  arriba_strand_flag: { type: [ 'null', {type: enum, name: arriba_std, symbols: ["auto", "reverse", "yes"]}] }
+  Chimeric_junction: {type: 'File'}
+
+outputs:
+  STAR-Fusion_results: {type: 'File?', outputSource: star_fusion_1-10-1/abridged_coding, doc: "STAR fusion detection from chimeric
+      reads"}
+  arriba_fusion_results: {type: 'File?', outputSource: arriba_fusion_2-2-1/arriba_fusions, doc: "Fusion output from Arriba"}
+  arriba_fusion_viz: {type: 'File?', outputSource: arriba_draw_2-2-1/arriba_pdf, doc: "pdf output from Arriba"}
+  annofuse_filtered_fusions_tsv: {type: 'File?', outputSource: annofuse/annofuse_filtered_fusions_tsv, doc: "Filtered fusions called
+      by annoFuse."}
+steps:
+  star_fusion_1-10-1:
+    run: ../tools/star_fusion_1.10.1_call.cwl
+    in:
+      Chimeric_junction: star_2-7-10a/chimeric_junctions
+      genome_tar: FusionGenome
+      output_basename: basename_picker/outname
+      genome_untar_path: star_fusion_genome_untar_path
+      compress_chimeric_junction: compress_chimeric_junction
+    out: [abridged_coding, chimeric_junction_compressed]
+  arriba_fusion_2-2-1:
+    run: ../tools/arriba_fusion_2.2.1.cwl
+    in:
+      genome_aligned_bam:
+        source: [samtools_sort/sorted_bam, samtools_sort/sorted_bai]
+        valueFrom: |
+          ${
+            var bundle = self[0];
+            bundle.secondaryFiles = [self[1]];
+            return bundle;
+          }
+      memory: arriba_memory
+      reference_fasta: reference_fasta
+      gtf_anno: gtf_anno
+      outFileNamePrefix: basename_picker/outname
+      arriba_strand_flag: strand_parse/arriba_std
+    out: [arriba_fusions]
+  arriba_draw_2-2-1:
+    run: ../tools/arriba_draw_2.2.1.cwl
+    in:
+      fusions: arriba_fusion_2-2-1/arriba_fusions
+      genome_aligned_bam:
+        source: [samtools_sort/sorted_bam, samtools_sort/sorted_bai]
+        valueFrom: |
+          ${
+            var bundle = self[0];
+            bundle.secondaryFiles = [self[1]];
+            return bundle;
+          }
+      gtf_anno: gtf_anno
+      memory: arriba_memory
+    out: [arriba_pdf]
+  annofuse:
+    run: ../workflow/kfdrc_annoFuse_wf.cwl
+    in:
+      sample_name: basename_picker/outsample
+      FusionGenome: fusion_annotator_ref
+      genome_untar_path: star_fusion_genome_untar_path
+      rsem_expr_file: rsem/gene_out
+      arriba_output_file: arriba_fusion_2-2-1/arriba_fusions
+      star_fusion_output_file: star_fusion_1-10-1/abridged_coding
+      col_num: annofuse_col_num
+      output_basename: basename_picker/outname
+    out: [annofuse_filtered_fusions_tsv]
+$namespaces:
+  sbg: https://sevenbridges.com
+hints:
+- class: "sbg:maxNumberOfParallelInstances"
+  value: 3

--- a/workflow/fusion_wf.cwl
+++ b/workflow/fusion_wf.cwl
@@ -43,59 +43,46 @@ outputs:
   arriba_fusion_viz: {type: 'File?', outputSource: arriba_draw_2-2-1/arriba_pdf, doc: "pdf output from Arriba"}
   annofuse_filtered_fusions_tsv: {type: 'File?', outputSource: annofuse/annofuse_filtered_fusions_tsv, doc: "Filtered fusions called
       by annoFuse."}
+  STAR_chimeric_junctions: {type: 'File?', outputSource: star_fusion_1-10-1/chimeric_junction_compressed, doc: "STAR chimeric junctions"}
 steps:
   star_fusion_1-10-1:
     run: ../tools/star_fusion_1.10.1_call.cwl
     in:
-      Chimeric_junction: star_2-7-10a/chimeric_junctions
+      Chimeric_junction: Chimeric_junction
       genome_tar: FusionGenome
-      output_basename: basename_picker/outname
-      genome_untar_path: star_fusion_genome_untar_path
+      output_basename: output_basename
+      genome_untar_path: genome_untar_path
       compress_chimeric_junction: compress_chimeric_junction
     out: [abridged_coding, chimeric_junction_compressed]
   arriba_fusion_2-2-1:
     run: ../tools/arriba_fusion_2.2.1.cwl
     in:
-      genome_aligned_bam:
-        source: [samtools_sort/sorted_bam, samtools_sort/sorted_bai]
-        valueFrom: |
-          ${
-            var bundle = self[0];
-            bundle.secondaryFiles = [self[1]];
-            return bundle;
-          }
+      genome_aligned_bam: genome_aligned_bam
       memory: arriba_memory
       reference_fasta: reference_fasta
       gtf_anno: gtf_anno
-      outFileNamePrefix: basename_picker/outname
-      arriba_strand_flag: strand_parse/arriba_std
+      outFileNamePrefix: output_basename
+      arriba_strand_flag: arriba_strand_flag
     out: [arriba_fusions]
   arriba_draw_2-2-1:
     run: ../tools/arriba_draw_2.2.1.cwl
     in:
       fusions: arriba_fusion_2-2-1/arriba_fusions
-      genome_aligned_bam:
-        source: [samtools_sort/sorted_bam, samtools_sort/sorted_bai]
-        valueFrom: |
-          ${
-            var bundle = self[0];
-            bundle.secondaryFiles = [self[1]];
-            return bundle;
-          }
+      genome_aligned_bam: genome_aligned_bam
       gtf_anno: gtf_anno
       memory: arriba_memory
     out: [arriba_pdf]
   annofuse:
     run: ../workflow/kfdrc_annoFuse_wf.cwl
     in:
-      sample_name: basename_picker/outsample
+      sample_name: sample_name
       FusionGenome: fusion_annotator_ref
-      genome_untar_path: star_fusion_genome_untar_path
-      rsem_expr_file: rsem/gene_out
+      genome_untar_path: genome_untar_path
+      rsem_expr_file: rsem_expr_file
       arriba_output_file: arriba_fusion_2-2-1/arriba_fusions
       star_fusion_output_file: star_fusion_1-10-1/abridged_coding
       col_num: annofuse_col_num
-      output_basename: basename_picker/outname
+      output_basename: output_basename
     out: [annofuse_filtered_fusions_tsv]
 $namespaces:
   sbg: https://sevenbridges.com

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -241,9 +241,11 @@ doc: |
   - `peOverlapNbasesMin`: 10
 
   ### Arriba
+  - `run_fusions`: Set to false to disable fusion detection
   - `arriba_memory`: Mem intensive tool. Set in GB
 
   ### STAR Fusion
+  - `run_fusions`: Set to false to disable fusion detection
   - `FusionGenome`: STAR-Fusion Cancer Transcriptome Analysis Toolkit (CTAT) Genome lib
   - `compress_chimeric_junction`: If part of a workflow, recommend compressing this file as final output
 
@@ -258,6 +260,7 @@ doc: |
   - `estimate_rspd`: Set this option if you want to estimate the read start position distribution (RSPD) from data
 
   ### annoFuse:
+  - `run_fusions`: Set to false to disable fusion detection
   - `sample_name`: Sample ID of the input reads. If not provided, will use reads1 file basename.
   - `annofuse_col_num`: 0-based column number in file of fusion name.
   - `fusion_annotator_ref`: Tar ball with fusion_annot_lib.idx and blast_pairs.idx from STAR-Fusion CTAT Genome lib. Can be same as FusionGenome, but only two files needed from that package
@@ -488,8 +491,9 @@ inputs:
   peOverlapMMp: {type: 'float?', default: 0.01, doc: "maximum proportion of mismatched bases in the overlap area. SF recommends 0.1"}
   peOverlapNbasesMin: {type: 'int?', default: 10, doc: "minimum number of overlap bases to trigger mates merging and realignment.
       Specify >0 value to switch on the 'merging of overlapping mates'algorithm. SF recommends 12,  AR recommends 10"}
+  run_fusions: {type: 'boolean?', default: true, doc: "Set to false to disable fusion detection"}
   arriba_memory: {type: 'int?', doc: "Mem intensive tool. Set in GB", default: 64}
-  FusionGenome: {type: 'File', doc: "STAR-Fusion CTAT Genome lib", "sbg:suggestedValue": {class: File, path: 62853e7ad63f7c6d8d7ae5a8,
+  FusionGenome: {type: 'File?', doc: "STAR-Fusion CTAT Genome lib", "sbg:suggestedValue": {class: File, path: 62853e7ad63f7c6d8d7ae5a8,
       name: GRCh38_v39_CTAT_lib_Mar242022.CUSTOM.tar.gz}}
   compress_chimeric_junction: {type: 'boolean?', default: true, doc: 'If part of a workflow, recommend compressing this file as final
       output'}
@@ -502,7 +506,7 @@ inputs:
       data", default: true}
   sample_name: {type: 'string?', doc: "Sample ID of the input reads. If not provided, will use reads1 file basename."}
   annofuse_col_num: {type: 'int?', doc: "0-based column number in file of fusion name.", default: 30}
-  fusion_annotator_ref: {type: 'File', doc: "Tar ball with fusion_annot_lib.idx and blast_pairs.idx from STAR-Fusion CTAT Genome lib.
+  fusion_annotator_ref: {type: 'File?', doc: "Tar ball with fusion_annot_lib.idx and blast_pairs.idx from STAR-Fusion CTAT Genome lib.
       Can be same as FusionGenome, but only two files needed from that package", "sbg:suggestedValue": {class: 'File', path: '63cff818facdd82011c8d6fe',
       name: 'GRCh38_v39_fusion_annot_custom.tar.gz'}}
   run_rmats: {type: 'boolean?', default: true, doc: "Set to false to disable rmats"}
@@ -527,22 +531,22 @@ outputs:
       supplied."}
   STAR_sorted_genomic_cram: {type: 'File', outputSource: samtools_bam_to_cram/output, doc: "STAR sorted and indexed genomic alignment
       cram"}
-  STAR_chimeric_junctions: {type: 'File?', outputSource: star_fusion_1-10-1/chimeric_junction_compressed, doc: "STAR chimeric junctions"}
+  STAR_chimeric_junctions: {type: 'File?', outputSource: fusion_workflow/STAR_chimeric_junctions, doc: "STAR chimeric junctions"}
   STAR_gene_count: {type: 'File', outputSource: star_2-7-10a/gene_counts, doc: "STAR genecounts"}
   STAR_junctions_out: {type: 'File', outputSource: star_2-7-10a/junctions_out, doc: "STARjunction reads"}
   STAR_final_log: {type: 'File', outputSource: star_2-7-10a/log_final_out, doc: "STAR metricslog file of unique, multi-mapping, unmapped,
       and chimeric reads"}
-  STAR-Fusion_results: {type: 'File?', outputSource: fusion_wf/abridged_coding, doc: "STAR fusion detection from chimeric
+  STAR-Fusion_results: {type: 'File?', outputSource: fusion_workflow/STAR-Fusion_results, doc: "STAR fusion detection from chimeric
       reads"}
-  arriba_fusion_results: {type: 'File?', outputSource: fusion_wf/arriba_fusions, doc: "Fusion output from Arriba"}
-  arriba_fusion_viz: {type: 'File?', outputSource: fusion_wf/arriba_pdf, doc: "pdf output from Arriba"}
+  arriba_fusion_results: {type: 'File?', outputSource: fusion_workflow/arriba_fusion_results, doc: "Fusion output from Arriba"}
+  arriba_fusion_viz: {type: 'File?', outputSource: fusion_workflow/arriba_fusion_viz, doc: "pdf output from Arriba"}
   RSEM_isoform: {type: 'File', outputSource: rsem/isoform_out, doc: "RSEM isoform expression estimates"}
   RSEM_gene: {type: 'File', outputSource: rsem/gene_out, doc: "RSEM gene expression estimates"}
   RNASeQC_Metrics: {type: 'File', outputSource: rna_seqc/Metrics, doc: "Metrics on mapping, intronic, exonic rates, count information,
       etc"}
   RNASeQC_counts: {type: 'File', outputSource: supplemental/RNASeQC_counts, doc: "Contains gene tpm, gene read, and exon counts"}
   kallisto_Abundance: {type: 'File', outputSource: kallisto/abundance_out, doc: "Gene abundance output from STAR genomic bam file"}
-  annofuse_filtered_fusions_tsv: {type: 'File?', outputSource: fusion_wf/annofuse_filtered_fusions_tsv, doc: "Filtered fusions called
+  annofuse_filtered_fusions_tsv: {type: 'File?', outputSource: fusion_workflow/annofuse_filtered_fusions_tsv, doc: "Filtered fusions called
       by annoFuse."}
   rmats_filtered_alternative_3_prime_splice_sites_jc: {type: 'File?', outputSource: rmats/filtered_alternative_3_prime_splice_sites_jc,
     doc: "Alternative 3 prime splice sites JC.txt output from RMATs containing only those calls with 10 or more junction spanning
@@ -794,6 +798,7 @@ steps:
     out: [abundance_out]
   fusion_workflow:
     run: ../workflow/fusion_wf.cwl
+    when: $(inputs.run_fusions)
     in:
       run_fusions: run_fusions
       Chimeric_junction: star_2-7-10a/chimeric_junctions
@@ -817,7 +822,7 @@ steps:
       rsem_expr_file: rsem/gene_out
       annofuse_col_num: annofuse_col_num
       output_basename: basename_picker/outname
-    out: [STAR-Fusion_results, arriba_fusion_results, arriba_fusion_viz, annofuse_filtered_fusions_tsv]
+    out: [STAR-Fusion_results, arriba_fusion_results, arriba_fusion_viz, annofuse_filtered_fusions_tsv, STAR_chimeric_junctions]
   samtools_bam_to_cram:
     run: ../tools/samtools_bam_to_cram.cwl
     in:

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -263,6 +263,7 @@ doc: |
   - `fusion_annotator_ref`: Tar ball with fusion_annot_lib.idx and blast_pairs.idx from STAR-Fusion CTAT Genome lib. Can be same as FusionGenome, but only two files needed from that package
 
   ### rmats
+  - `run_rmats`: Set to false to disable rmats
   - `rmats_variable_read_length`: Allow reads with lengths that differ from --readLength to be processed. --readLength will still be used to determine IncFormLen and SkipFormLen.
   - `rmats_novel_splice_sites`: Select for novel splice site detection or unannotated splice sites. 'true' to detect or add this parameter, 'false' to disable denovo detection. Tool Default: false
   - `rmats_stat_off`: Select to skip statistical analysis, either between two groups or on single sample group. 'true' to add this parameter. Tool default: false
@@ -504,6 +505,7 @@ inputs:
   fusion_annotator_ref: {type: 'File', doc: "Tar ball with fusion_annot_lib.idx and blast_pairs.idx from STAR-Fusion CTAT Genome lib.
       Can be same as FusionGenome, but only two files needed from that package", "sbg:suggestedValue": {class: 'File', path: '63cff818facdd82011c8d6fe',
       name: 'GRCh38_v39_fusion_annot_custom.tar.gz'}}
+  run_rmats: {type: 'boolean?', default: true, doc: "Set to false to disable rmats"}
   rmats_variable_read_length: {type: 'boolean?', default: true, doc: "Allow reads with lengths that differ from --readLength to be
       processed. --readLength will still be used to determine IncFormLen and SkipFormLen."}
   rmats_novel_splice_sites: {type: 'boolean?', doc: "Select for novel splice site detection or unannotated splice sites. 'true' to
@@ -530,7 +532,7 @@ outputs:
   STAR_junctions_out: {type: 'File', outputSource: star_2-7-10a/junctions_out, doc: "STARjunction reads"}
   STAR_final_log: {type: 'File', outputSource: star_2-7-10a/log_final_out, doc: "STAR metricslog file of unique, multi-mapping, unmapped,
       and chimeric reads"}
-  STAR-Fusion_results: {type: 'File', outputSource: star_fusion_1-10-1/abridged_coding, doc: "STAR fusion detection from chimeric
+  STAR-Fusion_results: {type: 'File?', outputSource: star_fusion_1-10-1/abridged_coding, doc: "STAR fusion detection from chimeric
       reads"}
   arriba_fusion_results: {type: 'File', outputSource: arriba_fusion_2-2-1/arriba_fusions, doc: "Fusion output from Arriba"}
   arriba_fusion_viz: {type: 'File', outputSource: arriba_draw_2-2-1/arriba_pdf, doc: "pdf output from Arriba"}
@@ -542,25 +544,25 @@ outputs:
   kallisto_Abundance: {type: 'File', outputSource: kallisto/abundance_out, doc: "Gene abundance output from STAR genomic bam file"}
   annofuse_filtered_fusions_tsv: {type: 'File?', outputSource: annofuse/annofuse_filtered_fusions_tsv, doc: "Filtered fusions called
       by annoFuse."}
-  rmats_filtered_alternative_3_prime_splice_sites_jc: {type: 'File', outputSource: rmats/filtered_alternative_3_prime_splice_sites_jc,
+  rmats_filtered_alternative_3_prime_splice_sites_jc: {type: 'File?', outputSource: rmats/filtered_alternative_3_prime_splice_sites_jc,
     doc: "Alternative 3 prime splice sites JC.txt output from RMATs containing only those calls with 10 or more junction spanning
       read counts of support"}
-  rmats_filtered_alternative_5_prime_splice_sites_jc: {type: 'File', outputSource: rmats/filtered_alternative_5_prime_splice_sites_jc,
+  rmats_filtered_alternative_5_prime_splice_sites_jc: {type: 'File?', outputSource: rmats/filtered_alternative_5_prime_splice_sites_jc,
     doc: "Alternative 5 prime splice sites JC.txt output from RMATs containing only those calls with 10 or more junction spanning
       read counts of support"}
-  rmats_filtered_mutually_exclusive_exons_jc: {type: 'File', outputSource: rmats/filtered_mutually_exclusive_exons_jc, doc: "Mutually
+  rmats_filtered_mutually_exclusive_exons_jc: {type: 'File?', outputSource: rmats/filtered_mutually_exclusive_exons_jc, doc: "Mutually
       exclusive exons JC.txt output from RMATs containing only those calls with 10 or more junction spanning read counts of support"}
-  rmats_filtered_retained_introns_jc: {type: 'File', outputSource: rmats/filtered_retained_introns_jc, doc: "Retained introns JC.txt
+  rmats_filtered_retained_introns_jc: {type: 'File?', outputSource: rmats/filtered_retained_introns_jc, doc: "Retained introns JC.txt
       output from RMATs containing only those calls with 10 or more junction spanning read counts of support"}
-  rmats_filtered_skipped_exons_jc: {type: 'File', outputSource: rmats/filtered_skipped_exons_jc, doc: "Skipped exons JC.txt output
+  rmats_filtered_skipped_exons_jc: {type: 'File?', outputSource: rmats/filtered_skipped_exons_jc, doc: "Skipped exons JC.txt output
       from RMATs containing only those calls with 10 or more junction spanning read counts of support"}
-  rmats_raw_alternative_3_prime_splice_sites_jc: {type: 'File', outputSource: rmats/raw_alternative_3_prime_splice_sites_jc}
-  rmats_raw_alternative_5_prime_splice_sites_jc: {type: 'File', outputSource: rmats/raw_alternative_5_prime_splice_sites_jc}
-  rmats_raw_mutually_exclusive_exons_jc: {type: 'File', outputSource: rmats/raw_mutually_exclusive_exons_jc}
-  rmats_raw_retained_introns_jc: {type: 'File', outputSource: rmats/raw_retained_introns_jc}
-  rmats_raw_skipped_exons_jc: {type: 'File', outputSource: rmats/raw_skipped_exons_jc}
-  rmats_raw_temp_read_outcomes: {type: 'File', outputSource: rmats/raw_temp_read_outcomes}
-  rmats_raw_summary_file: {type: 'File', outputSource: rmats/raw_summary_file}
+  rmats_raw_alternative_3_prime_splice_sites_jc: {type: 'File?', outputSource: rmats/raw_alternative_3_prime_splice_sites_jc}
+  rmats_raw_alternative_5_prime_splice_sites_jc: {type: 'File?', outputSource: rmats/raw_alternative_5_prime_splice_sites_jc}
+  rmats_raw_mutually_exclusive_exons_jc: {type: 'File?', outputSource: rmats/raw_mutually_exclusive_exons_jc}
+  rmats_raw_retained_introns_jc: {type: 'File?', outputSource: rmats/raw_retained_introns_jc}
+  rmats_raw_skipped_exons_jc: {type: 'File?', outputSource: rmats/raw_skipped_exons_jc}
+  rmats_raw_temp_read_outcomes: {type: 'File?', outputSource: rmats/raw_temp_read_outcomes}
+  rmats_raw_summary_file: {type: 'File?', outputSource: rmats/raw_summary_file}
   rmats_fromGTF: {type: 'File[]?', outputSource: rmats/rmats_fromGTF}
   t1k_genotype_tsv: {type: 'File?', outputSource: t1k/genotype_tsv, doc: "Genotyping results from T1k"}
 steps:
@@ -709,7 +711,9 @@ steps:
     out: [output, strandedness, read_length_median, read_length_stddev, is_paired_end]
   rmats:
     run: ../workflow/rmats_wf.cwl
+    when: $(inputs.run_rmats)
     in:
+      run_rmats: run_rmats
       gtf_annotation: gtf_anno
       sample_1_bams:
         source: samtools_sort/sorted_bam


### PR DESCRIPTION
This PR moves arriba, starfusion, and annofuse into a separate subworkflow and makes the fusion and rmats workflows optional.

Test runs:
[Default run with rmats and fusions](https://cavatica.sbgenomics.com/u/sicklera/cnh-rna-seq-dev/tasks/3e31c2af-663e-4ea6-8e5b-073432b0ba67/)
[Test run without fusions or rmats](https://cavatica.sbgenomics.com/u/sicklera/cnh-rna-seq-dev/tasks/e57ce27b-1e1a-4b90-ac63-a26c01816319/)

Original run for this sample: [here](https://cavatica.sbgenomics.com/u/sicklera/nf1-harmonization/tasks/d0fb0f54-1cfd-44ec-b224-6b076e07d601/)