### PR TITLE
 kf-rnaseq-workflow-cnh: Feature/fastp safeguard

### DIFF
--- a/subworkflows/preprocess_reads.cwl
+++ b/subworkflows/preprocess_reads.cwl
@@ -35,6 +35,7 @@ steps:
       root_name:
         source: reads_record
         valueFrom: $(self.reads1.basename.split('.')[0])
+      output_basename: output_basename
       sample_name: sample_name
       star_rg_line:
         source: reads_record
@@ -87,10 +88,7 @@ steps:
       quality_cutoff:
         source: reads_record
         valueFrom: $(self.quality_cutoff)
-      sample_name:
-        source: [output_basename, basename_picker/outname]
-        valueFrom: |
-          $(self.filter(function(e) { return e != null }).join('.'))
+      sample_name: basename_picker/outname
     out: [trimmedReadsR1, trimmedReadsR2, cutadapt_stats]
   build_out_record:
     run: ../tools/build_reads_record.cwl

--- a/subworkflows/preprocess_reads.cwl
+++ b/subworkflows/preprocess_reads.cwl
@@ -6,7 +6,8 @@ doc: |
   Pick basename
   Check for pairedness
   Convert to FASTQ
-  Cutadapt
+  Run fastp adapter detection
+  Run cutadapt only for manual adapters or validated fastp-detected Illumina adapters
 requirements:
 - class: SubworkflowFeatureRequirement
 - class: ScatterFeatureRequirement
@@ -25,7 +26,7 @@ outputs:
   processed_reads_record:
     type: ../schema/reads_record_type.yml#reads_record
     outputSource: build_out_record/out_rr
-  cutadapt_stats: {type: 'File?', outputSource: cutadapt_3-4/cutadapt_stats, doc: "Cutadapt stats output, only if adapter is supplied."}
+  cutadapt_stats: {type: 'File?', outputSource: cutadapt_3-4/cutadapt_stats, doc: "Cutadapt stats output, only if manual adapters are supplied or fastp-detected adapters pass safeguards."}
   fastp_json: {type: 'File?', outputSource: fastp_adapter_detect/fastp_json, doc: "fastp adapter detection JSON report for input reads."}
   fastp_html: {type: 'File?', outputSource: fastp_adapter_detect/fastp_html, doc: "fastp adapter detection HTML report for input reads."}
 steps:
@@ -62,12 +63,18 @@ steps:
         source: [prepare_aligned_reads/reads2, reads_record]
         valueFrom: |
           $(self[0] != null ? self[0] : self[1].reads2)
+      manual_r1_adapter:
+        source: reads_record
+        valueFrom: $(self.r1_adapter)
+      manual_r2_adapter:
+        source: reads_record
+        valueFrom: $(self.r2_adapter)
       sample_name: basename_picker/outname
-    out: [fastp_json, fastp_html, r1_adapter, r2_adapter]
+    out: [fastp_json, fastp_html, r1_adapter, r2_adapter, run_cutadapt]
   cutadapt_3-4:
-    # Skip if no adapter is available after combining detected and manual values
+    # Skip if manual adapters are absent and fastp's detected adapters fail percentage/seed safeguards
     run: ../tools/cutadapter_3.4.cwl
-    when: $(inputs.r1_adapter != null && String(inputs.r1_adapter).trim() != "" && String(inputs.r1_adapter).toLowerCase() != "unspecified")
+    when: $(inputs.r1_adapter != null && String(inputs.r1_adapter).trim().length > 0)
     in:
       readFilesIn1:
         source: [prepare_aligned_reads/reads1, reads_record]

--- a/tools/fastp_adapter_detect.cwl
+++ b/tools/fastp_adapter_detect.cwl
@@ -7,10 +7,11 @@ doc: |
   Trimmed reads are discarded (/tmp); only the reports are used downstream.
   Processes up to 1M reads by default. --detect_adapter_for_pe is added
   automatically when reads2 is provided.
-  Adapter sequences are extracted from the fastp JSON to plain text files
-  (r1_adapter.txt, r2_adapter.txt) so downstream steps can consume them
-  without relying on JSON parsing inside CWL expressions (which fails on
-  engines that truncate loadContents to 64 KiB).
+  Manual adapters override detected adapters. If no manual R1 adapter is
+  provided, detected adapters are selected for cutadapt only when fastp reports
+  at least 1% adapter-trimmed bases and the detected adapter sequence starts
+  with the Illumina seed AGATCGGA (R1 and R2 for paired-end reads). Otherwise
+  empty adapter files are emitted and cutadapt is skipped downstream.
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
@@ -38,6 +39,12 @@ inputs:
   sample_name:
     type: string
     doc: "Sample name used to name output reports"
+  manual_r1_adapter:
+    type: 'string?'
+    doc: "User-provided R1 adapter. If present and not 'unspecified', it overrides fastp detection."
+  manual_r2_adapter:
+    type: 'string?'
+    doc: "User-provided R2 adapter. Used with manual_r1_adapter when present; 'unspecified' is treated as empty."
   threads:
     type: 'int?'
     default: 4
@@ -75,8 +82,25 @@ arguments:
   - position: 100
     shellQuote: false
     valueFrom: >-
-      && sed -n 's/.*"read1_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json > r1_adapter.txt
-      && sed -n 's/.*"read2_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json > r2_adapter.txt
+      && detected_r1=\$(sed -n 's/.*"read1_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json)
+      && detected_r2=\$(sed -n 's/.*"read2_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json)
+      && adapter_trimmed_bases=\$(awk '/"adapter_trimmed_bases"/ {gsub(/[^0-9]/, "", $0); print; exit}' $(inputs.sample_name).fastp.json)
+      && total_bases=\$(awk '/"before_filtering"/ {in_before=1} in_before && /"total_bases"/ {gsub(/[^0-9]/, "", $0); print; exit}' $(inputs.sample_name).fastp.json)
+      && adapter_pct=\$(awk -v trimmed="$adapter_trimmed_bases" -v total="$total_bases" 'BEGIN {if (total > 0) printf "%.6f", 100 * trimmed / total; else print "0"}')
+      && manual_r1='$(inputs.manual_r1_adapter ? inputs.manual_r1_adapter : "")'
+      && manual_r2='$(inputs.manual_r2_adapter ? inputs.manual_r2_adapter : "")'
+      && manual_r1=\$(printf '%s' "$manual_r1" | awk '{$1=$1; print}')
+      && manual_r2=\$(printf '%s' "$manual_r2" | awk '{$1=$1; print}')
+      && if [ "\$(printf '%s' "$manual_r1" | tr '[:upper:]' '[:lower:]')" = "unspecified" ]; then manual_r1=""; fi
+      && if [ "\$(printf '%s' "$manual_r2" | tr '[:upper:]' '[:lower:]')" = "unspecified" ]; then manual_r2=""; fi
+      && adapter_pct_ok=false
+      && detected_adapters_ok=false
+      && if awk -v pct="$adapter_pct" 'BEGIN {exit pct < 1.0}'; then adapter_pct_ok=true; fi
+      && if printf '%s' "$detected_r1" | grep -q '^AGATCGGA' && { [ -z "$(inputs.reads2 != null ? "paired" : "")" ] || printf '%s' "$detected_r2" | grep -q '^AGATCGGA'; }; then detected_adapters_ok=true; fi
+      && : > r1_adapter.txt
+      && : > r2_adapter.txt
+      && printf 'false\n' > run_cutadapt.txt
+      && if [ -n "$manual_r1" ]; then printf '%s\n' "$manual_r1" > r1_adapter.txt; printf '%s\n' "$manual_r2" > r2_adapter.txt; printf 'true\n' > run_cutadapt.txt; elif [ "$adapter_pct_ok" = true ] && [ "$detected_adapters_ok" = true ]; then printf '%s\n' "$detected_r1" > r1_adapter.txt; printf '%s\n' "$detected_r2" > r2_adapter.txt; printf 'true\n' > run_cutadapt.txt; fi
 
 outputs:
   fastp_json:
@@ -91,15 +115,30 @@ outputs:
       glob: $(inputs.sample_name).fastp.html
   r1_adapter:
     type: 'string?'
-    doc: "Detected R1 adapter sequence (empty file => null)"
+    doc: "Adapter selected for R1 trimming after manual override and fastp safeguards"
     outputBinding:
       glob: r1_adapter.txt
       loadContents: true
-      outputEval: $(self[0].contents.trim() || null)
+      outputEval: |
+        ${
+          var adapter = self[0].contents.replace(/\u0000/g, "").trim();
+          return adapter && adapter.toLowerCase() !== "unspecified" ? adapter : null;
+        }
   r2_adapter:
     type: 'string?'
-    doc: "Detected R2 adapter sequence (empty file => null)"
+    doc: "Adapter selected for R2 trimming after manual override and fastp safeguards"
     outputBinding:
       glob: r2_adapter.txt
       loadContents: true
-      outputEval: $(self[0].contents.trim() || null)
+      outputEval: |
+        ${
+          var adapter = self[0].contents.replace(/\u0000/g, "").trim();
+          return adapter && adapter.toLowerCase() !== "unspecified" ? adapter : null;
+        }
+  run_cutadapt:
+    type: boolean
+    doc: "Whether cutadapt should run based on manual adapters or fastp safeguards"
+    outputBinding:
+      glob: run_cutadapt.txt
+      loadContents: true
+      outputEval: $(self[0].contents.trim() == "true")

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -126,11 +126,16 @@ doc: |
   and provide the necessary value.
 
   Users should also provide any adapter information to the workflow. This information includes:
-  - `r1_adapter`: If the R1 reads still have adapters, supply the adapter sequence here
-  - `r2_adapter`: If the R2 reads still have adapters, supply the adapter sequence here
+  - `r1_adapter`: If the R1 reads still have known adapters, supply the adapter sequence here. Manual adapters override fastp detection and run cutadapt.
+  - `r2_adapter`: If the R2 reads still have known adapters, supply the adapter sequence here.
   - `min_len`: If trimming adapters, what is the minimum length reads should have post trimming
   - `quality_base`: Phred scale used for quality scores of the reads
   - `quality_cutoff`: Quality trim cutoff, see https://cutadapt.readthedocs.io/en/v3.4/guide.html#quality-trimming for how 5' 3' is handled
+
+  If no manual R1 adapter is supplied, the workflow runs fastp adapter detection.
+  Cutadapt runs on detected adapters only when fastp reports at least 1% adapter-trimmed
+  bases and the detected adapter sequence starts with the Illumina seed AGATCGGA
+  (R1 and R2 for paired-end reads). Otherwise cutadapt is skipped.
 
   At this time the workflow only accepts a single input for these options. If you
   have multiple read groups with unique trimming needs, we recommend pre-trimming
@@ -287,8 +292,9 @@ doc: |
      - For SE FASTQ input, enter the single ends reads file in `reads1` and leave `reads2` empty as it is optional.
      - For alignment input (SAM/BAM/CRAM), please enter the reads file in `reads1` and leave `reads2` empty as it is optional.
   2. `r1_adapter` and `r2_adapter` are OPTIONAL:
-     - If the input reads have already been trimmed, leave these as null and cutadapt step will simple pass on the FASTQ files to STAR.
-     - If they do need trimming, supply the adapters and the cutadapt step will trim, and pass trimmed FASTQs along.
+     - If the input reads have already been trimmed, leave these as null. The workflow will run fastp detection and skip cutadapt unless detected adapters pass safeguards.
+     - If they do need trimming with known adapters, supply the adapters and cutadapt will trim, then pass trimmed FASTQs along.
+     - If adapters are not supplied, cutadapt runs only when fastp reports at least 1% adapter-trimmed bases and the detected adapter sequence starts with AGATCGGA (R1 and R2 for paired-end reads).
      - `min_len` if adapter is trimmed, currently set to min `20` bp. Change this as you see fit
      - `quality_base` set to Phred scale `33` by default if trimming. There was a weird time when `64` was used - change if different
      - `quality_cutoff` if adapter is trimmed and you want to set a min bp quality. A single value will apply to both paired ends, 2 values will allow you to assign a different one to each (unusual)


### PR DESCRIPTION
**Summary**
Adds safeguards so cutadapt runs only when adapters are trustworthy.

**Changes**
- Added manual adapter override + guarded fastp auto-detection logic in `fastp_adapter_detect.cwl`.
- In `preprocess_reads.cwl`, passed manual adapters into fastp step and used selected adapters for cutadapt gating.

**Updated docs in:**
`fastp_adapter_detect.cwl`, `preprocess_reads.cwl` and `kfdrc_RNAseq_workflow.cwl`

**Decision logic**
```
if manual_r1_adapter exists:
    use manual adapters; run cutadapt
else:
    adapter_pct = 100 * adapter_trimmed_bases / total_bases_before_filtering
    if adapter_pct < 1.0:
        skip cutadapt
    else:
        if detected_adapters start with "AGATCGGA" (check against illumina adapter pool):
            use detected adapters; run cutadapt
        else:
            skip cutadapt (or require manual adapter input)
```

**Tests on Cavatica**
- [Sample ](https://cavatica.sbgenomics.com/u/childrens-bti/impact-wf-dev/tasks/8c2cb1aa-1e57-487f-8a77-f685bb035229/)with normal adapters -> cutadapt
- [Sample ](https://cavatica.sbgenomics.com/u/childrens-bti/rokita-itt-860/tasks/ba412f3d-7455-4f97-98f7-5dd0e3d00a2d/)with <1% adapters and likely already trimmed -> skipped cutadapt