### PR TITLE
 kf-rnaseq-workflow-cnh: Chao/fix se cutadapt

### DIFF
--- a/tools/cutadapter_3.4.cwl
+++ b/tools/cutadapter_3.4.cwl
@@ -17,6 +17,16 @@ arguments:
     shellQuote: false
     valueFrom: >-
       -o TRIMMED.$(inputs.readFilesIn1.basename)
+  - position: 2
+    shellQuote: false
+    valueFrom: >-
+      ${
+        var arg = "";
+        if (inputs.r2_adapter && inputs.r2_adapter.trim().length > 0){
+          arg = " -A " + inputs.r2_adapter;
+        }
+        return arg;
+      }
   - position: 3
     shellQuote: false
     valueFrom: >-
@@ -34,7 +44,7 @@ arguments:
 
 inputs:
   r1_adapter: { type: string, doc: "read1 adapter sequence", inputBinding: {prefix: "-a", position: 1} }
-  r2_adapter: { type: 'string?', doc: "read2 adapter sequence, if paired", inputBinding: {prefix: "-A", position: 3} }
+  r2_adapter: { type: 'string?', doc: "read2 adapter sequence, if paired" }
   min_len: { type: 'int?', doc: "If you do not use this option, reads that have a length of zero (empty reads) are kept in the output", default: 20,
     inputBinding: { prefix: "-m", position: 4 } }
   quality_base: { type: 'int?', doc: "Phred scale used", default: 33,

--- a/tools/fastp_adapter_detect.cwl
+++ b/tools/fastp_adapter_detect.cwl
@@ -10,7 +10,8 @@ doc: |
   Manual adapters override detected adapters. If no manual R1 adapter is
   provided, detected adapters are selected for cutadapt only when fastp reports
   at least 1% adapter-trimmed bases and the detected adapter sequence starts
-  with the Illumina seed AGATCGGA (R1 and R2 for paired-end reads). Otherwise
+  with standard Illumina adapter seeds: AGATCGGA (TruSeq) or CTGTCTCT (Nextera).
+  For paired-end reads, both R1 and R2 must pass validation. Otherwise
   empty adapter files are emitted and cutadapt is skipped downstream.
 requirements:
   - class: ShellCommandRequirement
@@ -96,7 +97,7 @@ arguments:
       && adapter_pct_ok=false
       && detected_adapters_ok=false
       && if awk -v pct="$adapter_pct" 'BEGIN {exit pct < 1.0}'; then adapter_pct_ok=true; fi
-      && if printf '%s' "$detected_r1" | grep -q '^AGATCGGA' && { [ -z "$(inputs.reads2 != null ? "paired" : "")" ] || printf '%s' "$detected_r2" | grep -q '^AGATCGGA'; }; then detected_adapters_ok=true; fi
+      && if printf '%s' "$detected_r1" | grep -qE '^(AGATCGGA|CTGTCTCT)' && { [ -z "$(inputs.reads2 != null ? "paired" : "")" ] || printf '%s' "$detected_r2" | grep -qE '^(AGATCGGA|CTGTCTCT)'; }; then detected_adapters_ok=true; fi
       && : > r1_adapter.txt
       && : > r2_adapter.txt
       && printf 'false\n' > run_cutadapt.txt

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -1,9 +1,9 @@
 cwlVersion: v1.2
 class: Workflow
 id: kfdrc-rnaseq-workflow-cnh
-label: Kids First DRC RNAseq Workflow
+label: Kids First DRC RNAseq Workflow (CNH)
 doc: |
-  # Kids First RNA-Seq Workflow V5
+  # Kids First RNA-Seq Workflow V5 (CNH)
 
   This is the Kids First RNA-Seq pipeline, which calculates gene and transcript isoform expression, detects fusions and splice junctions.
   We have transitioned to this current version which upgrades several software components.
@@ -877,5 +877,5 @@ hints:
 - SE
 - STAR
 "sbg:links":
-- id: 'https://github.com/childrens-bti/kf-rnaseq-workflow-cnh/releases/tag/v1.2.0'
+- id: 'https://github.com/childrens-bti/kf-rnaseq-workflow-cnh'
   label: github-release

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -877,5 +877,5 @@ hints:
 - SE
 - STAR
 "sbg:links":
-- id: 'https://github.com/childrens-bti/kf-rnaseq-workflow-cnh'
+- id: 'https://github.com/childrens-bti/kf-rnaseq-workflow-cnh/releases/tag/v1.2.2'
   label: github-release


### PR DESCRIPTION
## Problem

Cutadapt was failing on single-end data with error:
```
exec /usr/bin/sh: invalid argument
cutadapt -j 8 -o TRIMMED.xxx.fastq.gz -a ADAPTER -A  -m 20 ... failed with exit code 255
```

The empty `-A` flag (for R2 adapters) was being added even for single-end data.

## Solution

**Commit 1:** Make cutadapt `-A` flag conditional  
- Changed `tools/cutadapter_3.4.cwl` to only add `-A` when `r2_adapter` has a value
- Fixes single-end processing

**Commit 2:** Accept Nextera adapters in validation  
- Updated `tools/fastp_adapter_detect.cwl` regex from `^AGATCGGA` to `^(AGATCGGA|CTGTCTCT)`
- Allows auto-detection of both TruSeq and Nextera adapters

## Testing
https://cavatica.sbgenomics.com/u/childrens-bti/rokita-itt-906/tasks/d27adf1d-629d-4de7-8dcc-219ade149185/

Will update repo to new release v1.2.1 after this PR merge.