### PR TITLE
Upgrade fastp and support one-sided adapter trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Alternatively, if you would like to run it locally using `cwltool`, a basic prim
 This workflow is the current production workflow, equivalent to this [CAVATICA public app](https://cavatica.sbgenomics.com/public/apps#cavatica/apps-publisher/kfdrc-rnaseq-workflow).
 
 ### fastp
-fastp v0.23.4: Automatic adapter detection from raw reads before trimming.
+fastp v1.3.6: Automatic adapter detection from raw reads before trimming.
  - [Github](https://github.com/OpenGene/fastp)
  - [Publication](https://doi.org/10.1093/bioinformatics/bty560)
 ### Cutadapt
@@ -127,6 +127,7 @@ and provide the necessary value.
 The workflow automatically detects adapter sequences using fastp (up to 1M reads sampled per run). Adapter sequences are parsed directly from the fastp JSON report in the same detection step. Detected adapters are used to run Cutadapt unless none are found, in which case the step is skipped. Users may also supply adapters manually:
 - `r1_adapter`: Override detected R1 adapter with this sequence
 - `r2_adapter`: Override detected R2 adapter with this sequence
+Each read end is handled independently: Cutadapt uses `-a` for R1 and `-A` for R2 when the corresponding adapter exists.
 - `min_len`: If trimming adapters, what is the minimum length reads should have post trimming
 - `quality_base`: Phred scale used for quality scores of the reads
 - `quality_cutoff`: Quality trim cutoff, see https://cutadapt.readthedocs.io/en/v3.4/guide.html#quality-trimming for how 5' 3' is handled
@@ -282,7 +283,7 @@ These are the defaults set by the workflow:
    - For alignment input (SAM/BAM/CRAM), please enter the reads file in `reads1` and leave `reads2` empty as it is optional.
 2. Adapter trimming is handled automatically:
    - fastp is run on every input to detect adapters, and adapter sequences are read directly from the generated fastp JSON report. If adapters are detected, Cutadapt is run automatically.
-   - If no adapters are detected and `r1_adapter` is not supplied, the Cutadapt step is skipped and untrimmed FASTQs are passed directly to STAR.
+   - If neither adapter is detected or supplied, the Cutadapt step is skipped and untrimmed FASTQs are passed directly to STAR.
    - `r1_adapter` and `r2_adapter` are OPTIONAL overrides. Supply them to force a specific adapter sequence instead of the auto-detected one.
    - `min_len` if adapter is trimmed, currently set to min `20` bp. Change this as you see fit
    - `quality_base` set to Phred scale `33` by default if trimming. There was a weird time when `64` was used - change if different

--- a/docs/dockers_rnaseq.md
+++ b/docs/dockers_rnaseq.md
@@ -12,7 +12,7 @@ basename_picker.cwl|None
 build_reads_record.cwl|None
 cutadapter_3.4.cwl|pgc-images.sbgenomics.com/d3b-bixu/cutadapt:3.4
 expression_parse_strand_param.cwl|None
-fastp_adapter_detect.cwl|quay.io/biocontainers/fastp:0.23.4--h5f740d0_0
+fastp_adapter_detect.cwl|quay.io/biocontainers/fastp:1.3.6--h43da1c4_0
 format_arriba_fusion_file.cwl|pgc-images.sbgenomics.com/d3b-bixu/annofuse:0.92.0
 fusion_annotator.cwl|pgc-images.sbgenomics.com/d3b-bixu/fusionannotator:0.1.1
 kallisto_calc_expression.cwl|images.sbgenomics.com/uros_sipetic/kallisto:0.43.1

--- a/subworkflows/preprocess_reads.cwl
+++ b/subworkflows/preprocess_reads.cwl
@@ -72,9 +72,10 @@ steps:
       sample_name: basename_picker/outname
     out: [fastp_json, fastp_html, r1_adapter, r2_adapter, run_cutadapt]
   cutadapt_3-4:
-    # Skip if manual adapters are absent and fastp's detected adapters fail percentage/seed safeguards
+    # Skip if neither read end has a manual or validated fastp-detected adapter
     run: ../tools/cutadapter_3.4.cwl
-    when: $(inputs.r1_adapter != null && String(inputs.r1_adapter).trim().length > 0)
+    when: >-
+      $((inputs.r1_adapter != null && String(inputs.r1_adapter).trim().length > 0) || (inputs.r2_adapter != null && String(inputs.r2_adapter).trim().length > 0))
     in:
       readFilesIn1:
         source: [prepare_aligned_reads/reads1, reads_record]

--- a/tools/cutadapter_3.4.cwl
+++ b/tools/cutadapter_3.4.cwl
@@ -22,8 +22,11 @@ arguments:
     valueFrom: >-
       ${
         var arg = "";
+        if (inputs.r1_adapter && inputs.r1_adapter.trim().length > 0){
+          arg += " -a " + inputs.r1_adapter;
+        }
         if (inputs.r2_adapter && inputs.r2_adapter.trim().length > 0){
-          arg = " -A " + inputs.r2_adapter;
+          arg += " -A " + inputs.r2_adapter;
         }
         return arg;
       }
@@ -32,7 +35,7 @@ arguments:
     valueFrom: >-
       ${
         var arg = "";
-        if (inputs.r2_adapter && inputs.readFilesIn2){
+        if (inputs.readFilesIn2){
           arg = " -p TRIMMED." + inputs.readFilesIn2.basename;
         }
         return arg;
@@ -43,7 +46,7 @@ arguments:
       > $(inputs.sample_name).cutadapt_results.txt
 
 inputs:
-  r1_adapter: { type: string, doc: "read1 adapter sequence", inputBinding: {prefix: "-a", position: 1} }
+  r1_adapter: { type: 'string?', doc: "read1 adapter sequence" }
   r2_adapter: { type: 'string?', doc: "read2 adapter sequence, if paired" }
   min_len: { type: 'int?', doc: "If you do not use this option, reads that have a length of zero (empty reads) are kept in the output", default: 20,
     inputBinding: { prefix: "-m", position: 4 } }

--- a/tools/cutadapter_3.4.cwl
+++ b/tools/cutadapter_3.4.cwl
@@ -18,18 +18,13 @@ arguments:
     valueFrom: >-
       -o TRIMMED.$(inputs.readFilesIn1.basename)
   - position: 2
-    shellQuote: false
+    prefix: -a
     valueFrom: >-
-      ${
-        var arg = "";
-        if (inputs.r1_adapter && inputs.r1_adapter.trim().length > 0){
-          arg += " -a " + inputs.r1_adapter;
-        }
-        if (inputs.r2_adapter && inputs.r2_adapter.trim().length > 0){
-          arg += " -A " + inputs.r2_adapter;
-        }
-        return arg;
-      }
+      $(inputs.r1_adapter && inputs.r1_adapter.trim().length > 0 ? inputs.r1_adapter : null)
+  - position: 2
+    prefix: -A
+    valueFrom: >-
+      $(inputs.r2_adapter && inputs.r2_adapter.trim().length > 0 ? inputs.r2_adapter : null)
   - position: 3
     shellQuote: false
     valueFrom: >-

--- a/tools/fastp_adapter_detect.cwl
+++ b/tools/fastp_adapter_detect.cwl
@@ -1,22 +1,21 @@
 cwlVersion: v1.2
 class: CommandLineTool
 id: fastp_adapter_detect
-label: "fastp v0.23.4 Adapter Detection"
+label: "fastp v1.3.6 Adapter Detection"
 doc: |
   Run fastp to detect adapter sequences and produce JSON and HTML QC reports.
   Trimmed reads are discarded (/tmp); only the reports are used downstream.
   Processes up to 1M reads by default. --detect_adapter_for_pe is added
   automatically when reads2 is provided.
-  Manual adapters override detected adapters. If no manual R1 adapter is
-  provided, detected adapters are selected for cutadapt only when fastp reports
-  at least 1% adapter-trimmed bases and the detected adapter sequence starts
-  with standard Illumina adapter seeds: AGATCGGA (TruSeq) or CTGTCTCT (Nextera).
-  For paired-end reads, both R1 and R2 must pass validation. Otherwise
-  empty adapter files are emitted and cutadapt is skipped downstream.
+  Manual adapters override detected adapters independently for each read end.
+  Detected adapters are selected for cutadapt only when fastp reports at least
+  1% adapter-trimmed bases and each detected sequence starts with a standard
+  Illumina adapter seed: AGATCGGA (TruSeq) or CTGTCTCT (Nextera). Cutadapt runs
+  when at least one read end has a manual or validated detected adapter.
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'quay.io/biocontainers/fastp:0.23.4--h5f740d0_0'
+    dockerPull: 'quay.io/biocontainers/fastp:1.3.6--h43da1c4_0'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: $(inputs.threads)
@@ -45,7 +44,7 @@ inputs:
     doc: "User-provided R1 adapter. If present and not 'unspecified', it overrides fastp detection."
   manual_r2_adapter:
     type: 'string?'
-    doc: "User-provided R2 adapter. Used with manual_r1_adapter when present; 'unspecified' is treated as empty."
+    doc: "User-provided R2 adapter. Independently overrides R2 detection; 'unspecified' is treated as empty."
   threads:
     type: 'int?'
     default: 4
@@ -95,13 +94,17 @@ arguments:
       && if [ "\$(printf '%s' "$manual_r1" | tr '[:upper:]' '[:lower:]')" = "unspecified" ]; then manual_r1=""; fi
       && if [ "\$(printf '%s' "$manual_r2" | tr '[:upper:]' '[:lower:]')" = "unspecified" ]; then manual_r2=""; fi
       && adapter_pct_ok=false
-      && detected_adapters_ok=false
+      && detected_r1_ok=false
+      && detected_r2_ok=false
       && if awk -v pct="$adapter_pct" 'BEGIN {exit pct < 1.0}'; then adapter_pct_ok=true; fi
-      && if printf '%s' "$detected_r1" | grep -qE '^(AGATCGGA|CTGTCTCT)' && { [ -z "$(inputs.reads2 != null ? "paired" : "")" ] || printf '%s' "$detected_r2" | grep -qE '^(AGATCGGA|CTGTCTCT)'; }; then detected_adapters_ok=true; fi
+      && if printf '%s' "$detected_r1" | grep -qE '^(AGATCGGA|CTGTCTCT)'; then detected_r1_ok=true; fi
+      && if [ -n "$(inputs.reads2 != null ? "paired" : "")" ] && printf '%s' "$detected_r2" | grep -qE '^(AGATCGGA|CTGTCTCT)'; then detected_r2_ok=true; fi
       && : > r1_adapter.txt
       && : > r2_adapter.txt
       && printf 'false\n' > run_cutadapt.txt
-      && if [ -n "$manual_r1" ]; then printf '%s\n' "$manual_r1" > r1_adapter.txt; printf '%s\n' "$manual_r2" > r2_adapter.txt; printf 'true\n' > run_cutadapt.txt; elif [ "$adapter_pct_ok" = true ] && [ "$detected_adapters_ok" = true ]; then printf '%s\n' "$detected_r1" > r1_adapter.txt; printf '%s\n' "$detected_r2" > r2_adapter.txt; printf 'true\n' > run_cutadapt.txt; fi
+      && if [ -n "$manual_r1" ]; then printf '%s\n' "$manual_r1" > r1_adapter.txt; elif [ "$adapter_pct_ok" = true ] && [ "$detected_r1_ok" = true ]; then printf '%s\n' "$detected_r1" > r1_adapter.txt; fi
+      && if [ -n "$(inputs.reads2 != null ? "paired" : "")" ]; then if [ -n "$manual_r2" ]; then printf '%s\n' "$manual_r2" > r2_adapter.txt; elif [ "$adapter_pct_ok" = true ] && [ "$detected_r2_ok" = true ]; then printf '%s\n' "$detected_r2" > r2_adapter.txt; fi; fi
+      && if [ -s r1_adapter.txt ] || [ -s r2_adapter.txt ]; then printf 'true\n' > run_cutadapt.txt; fi
 
 outputs:
   fastp_json:

--- a/tools/fastp_adapter_detect.cwl
+++ b/tools/fastp_adapter_detect.cwl
@@ -12,6 +12,9 @@ doc: |
   1% adapter-trimmed bases and each detected sequence starts with a standard
   Illumina adapter seed: AGATCGGA (TruSeq) or CTGTCTCT (Nextera). Cutadapt runs
   when at least one read end has a manual or validated detected adapter.
+  In fastp, a single-end report omits the entire
+  adapter_cutting section when no adapter is detected. Paired-end reports retain
+  the section and report "unspecified" for an end where no adapter is detected.
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -542,9 +542,9 @@ outputs:
   cutadapt_stats: {type: 'File[]?', outputSource: preprocess_reads/cutadapt_stats, doc: "Cutadapt stats output, only if adapter is
       supplied."}
   fastp_adapter_json: {type: 'File[]?', outputSource: preprocess_reads/fastp_json, doc: "fastp adapter detection JSON reports (one per
-      paired-end sample). Contains detected adapter sequences and QC metrics."}
+      processed reads record, for both SE and PE inputs). Contains detected adapter sequences and QC metrics."}
   fastp_adapter_html: {type: 'File[]?', outputSource: preprocess_reads/fastp_html, doc: "fastp adapter detection HTML reports (one per
-      paired-end sample)."}
+      processed reads record, for both SE and PE inputs)."}
   STAR_sorted_genomic_cram: {type: 'File', outputSource: samtools_bam_to_cram/output, doc: "STAR sorted and indexed genomic alignment
       cram"}
   STAR_chimeric_junctions: {type: 'File?', outputSource: fusion_workflow/STAR_chimeric_junctions, doc: "STAR chimeric junctions"}

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -880,5 +880,5 @@ hints:
 - SE
 - STAR
 "sbg:links":
-- id: 'https://github.com/childrens-bti/kf-rnaseq-workflow-cnh/releases/tag/v1.2.4'
+- id: 'https://github.com/childrens-bti/kf-rnaseq-workflow-cnh/releases/tag/v1.2.3'
   label: github-release

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -880,5 +880,5 @@ hints:
 - SE
 - STAR
 "sbg:links":
-- id: 'https://github.com/childrens-bti/kf-rnaseq-workflow-cnh/releases/tag/v1.2.3'
+- id: 'https://github.com/childrens-bti/kf-rnaseq-workflow-cnh/releases/tag/v1.2.4'
   label: github-release

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -132,10 +132,11 @@ doc: |
   - `quality_base`: Phred scale used for quality scores of the reads
   - `quality_cutoff`: Quality trim cutoff, see https://cutadapt.readthedocs.io/en/v3.4/guide.html#quality-trimming for how 5' 3' is handled
 
-  If no manual R1 adapter is supplied, the workflow runs fastp adapter detection.
-  Cutadapt runs on detected adapters only when fastp reports at least 1% adapter-trimmed
-  bases and the detected adapter sequence starts with the Illumina seed AGATCGGA
-  (R1 and R2 for paired-end reads). Otherwise cutadapt is skipped.
+  Manual adapters override fastp detection independently for each read end.
+  Each detected adapter is selected independently when fastp reports at least 1%
+  adapter-trimmed bases and its sequence starts with an Illumina seed (AGATCGGA or
+  CTGTCTCT). Cutadapt runs when either adapter is selected, using -a for R1 and -A
+  for R2. If neither adapter is selected, cutadapt is skipped.
 
   At this time the workflow only accepts a single input for these options. If you
   have multiple read groups with unique trimming needs, we recommend pre-trimming
@@ -294,7 +295,7 @@ doc: |
   2. `r1_adapter` and `r2_adapter` are OPTIONAL:
      - If the input reads have already been trimmed, leave these as null. The workflow will run fastp detection and skip cutadapt unless detected adapters pass safeguards.
      - If they do need trimming with known adapters, supply the adapters and cutadapt will trim, then pass trimmed FASTQs along.
-     - If adapters are not supplied, cutadapt runs only when fastp reports at least 1% adapter-trimmed bases and the detected adapter sequence starts with AGATCGGA (R1 and R2 for paired-end reads).
+     - If adapters are not supplied, each read end is evaluated independently; cutadapt runs with `-a` for a validated R1 adapter, `-A` for a validated R2 adapter, or both when both are present.
      - `min_len` if adapter is trimmed, currently set to min `20` bp. Change this as you see fit
      - `quality_base` set to Phred scale `33` by default if trimming. There was a weird time when `64` was used - change if different
      - `quality_cutoff` if adapter is trimmed and you want to set a min bp quality. A single value will apply to both paired ends, 2 values will allow you to assign a different one to each (unusual)

--- a/workflow/kfdrc_star_diploid_wf.cwl
+++ b/workflow/kfdrc_star_diploid_wf.cwl
@@ -348,7 +348,8 @@ steps:
   cutadapt_3-4:
     # Skip if no adapter given, get fastq from prev step if not null or wf input
     run: ../tools/cutadapter_3.4.cwl
-    when: $(inputs.r1_adapter != null)
+    when: >-
+      $((inputs.r1_adapter != null && String(inputs.r1_adapter).trim().length > 0) || (inputs.r2_adapter != null && String(inputs.r2_adapter).trim().length > 0))
     in:
       readFilesIn1:
         source: [align2fastq/fq1, reads1]

--- a/workflow/kfdrc_star_diploid_wf.cwl
+++ b/workflow/kfdrc_star_diploid_wf.cwl
@@ -348,8 +348,7 @@ steps:
   cutadapt_3-4:
     # Skip if no adapter given, get fastq from prev step if not null or wf input
     run: ../tools/cutadapter_3.4.cwl
-    when: >-
-      $((inputs.r1_adapter != null && String(inputs.r1_adapter).trim().length > 0) || (inputs.r2_adapter != null && String(inputs.r2_adapter).trim().length > 0))
+    when: $(inputs.r1_adapter != null)
     in:
       readFilesIn1:
         source: [align2fastq/fq1, reads1]


### PR DESCRIPTION
## Summary

Upgrade fastp from 0.23.4 to 1.3.6 and allow adapter trimming when an adapter is detected for only R1 or R2.

## Changes

- Update fastp image to `1.3.6--h43da1c4_0`
- Evaluate detected R1 and R2 adapters independently
- Set `run_cutadapt=true` when either adapter is selected
- Support:
  - R1 only: `cutadapt -a`
  - R2 only: `cutadapt -A`
  - Both: `cutadapt -a ... -A ...`
- Preserve paired outputs when trimming only one read end
- Skip Cutadapt when neither adapter passes safeguards
- Update workflow documentation and container inventory

## Local testing

- Validated all affected CWL tools and workflows with `cwltool`
- Tested fastp 1.3.6 on 1 million HA_1 read pairs
- Compared fastp 0.23.4 and 1.3.6 adapter detection
- Ran full preprocessing tests with 20,000 synthetic read pairs:
  - R1 adapter only: Cutadapt ran with `-a` only
  - R2 adapter only: Cutadapt ran with `-A` only
  - Both adapters: Cutadapt ran with both flags
  - Neither adapter: Cutadapt was skipped
- Confirmed R1 and R2 trimmed outputs retain equal read counts
- Confirmed paired read identifiers remain synchronized
- `git diff --check` passes

## CAVATICA testing

CAVATICA testing gave the right output: https://cavatica.sbgenomics.com/u/childrens-bti/gilbert-itt-866/tasks/3ab5a5bf-122b-4be3-8d39-a65185174a99/