### PR TITLE
Refine fastp adapter safeguard for known adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ user does not provide the value and the workflow is unable to guess the value, t
 workflow will fail. Please check the error message to see the cause of the failure
 and provide the necessary value.
 
-The workflow automatically detects adapter sequences using fastp (up to 1M reads sampled per run). Adapter sequences are parsed directly from the fastp JSON report in the same detection step. Detected adapters are used to run Cutadapt unless none are found, in which case the step is skipped. Users may also supply adapters manually:
+The workflow automatically detects adapter sequences using fastp (up to 1M reads sampled per run). Adapter sequences are parsed from the fastp JSON report and checked against fastp's built-in known-adapter pool. Known adapters are passed to Cutadapt even when fastp reports less than 1% adapter content; de novo or otherwise unrecognized detections are skipped. If no known or manually supplied adapter remains, Cutadapt is skipped. Users may also supply adapters manually:
 - `r1_adapter`: Override detected R1 adapter with this sequence
 - `r2_adapter`: Override detected R2 adapter with this sequence
 Each read end is handled independently: Cutadapt uses `-a` for R1 and `-A` for R2 when the corresponding adapter exists.
@@ -282,8 +282,9 @@ These are the defaults set by the workflow:
    - For SE FASTQ input, enter the single ends reads file in `reads1` and leave `reads2` empty as it is optional.
    - For alignment input (SAM/BAM/CRAM), please enter the reads file in `reads1` and leave `reads2` empty as it is optional.
 2. Adapter trimming is handled automatically:
-   - fastp is run on every input to detect adapters, and adapter sequences are read directly from the generated fastp JSON report. If adapters are detected, Cutadapt is run automatically.
-   - If neither adapter is detected or supplied, the Cutadapt step is skipped and untrimmed FASTQs are passed directly to STAR.
+   - fastp is run on every input to detect adapters, and adapter sequences are read from the generated fastp JSON report and checked against fastp's built-in known-adapter pool.
+   - Known fastp adapters are passed to Cutadapt even when fastp reports less than 1% adapter content. De novo or otherwise unrecognized detections are skipped.
+   - If neither a known adapter nor a manual adapter is selected, the Cutadapt step is skipped and untrimmed FASTQs are passed directly to STAR.
    - `r1_adapter` and `r2_adapter` are OPTIONAL overrides. Supply them to force a specific adapter sequence instead of the auto-detected one.
    - `min_len` if adapter is trimmed, currently set to min `20` bp. Change this as you see fit
    - `quality_base` set to Phred scale `33` by default if trimming. There was a weird time when `64` was used - change if different
@@ -319,7 +320,7 @@ These are the defaults set by the workflow:
    - Additionally for FASTQ inputs, if no `outSAMattrRGline` input is provided a disclaimer will be added to the `@RG` header line that reads: `DS:Values for this read group were auto-generated and may not reflect the true read group information.`
 
 ## Outputs
-- `cutadapt_stats`: Cutadapt stats output, only if an adapter is detected or supplied.
+- `cutadapt_stats`: Cutadapt stats output, only if a known fastp adapter is selected or an adapter is supplied manually.
 - `STAR_sorted_genomic_cram`: STAR sorted and indexed genomic alignment CRAM
 - `STAR_chimeric_junctions`: STAR chimeric junctions
 - `STAR_gene_count`: STAR genecounts

--- a/subworkflows/preprocess_reads.cwl
+++ b/subworkflows/preprocess_reads.cwl
@@ -7,7 +7,7 @@ doc: |
   Check for pairedness
   Convert to FASTQ
   Run fastp adapter detection
-  Run cutadapt only for manual adapters or validated fastp-detected Illumina adapters
+  Run cutadapt only for manual adapters or adapters from fastp's built-in pool
 requirements:
 - class: SubworkflowFeatureRequirement
 - class: ScatterFeatureRequirement

--- a/tools/fastp_adapter_detect.cwl
+++ b/tools/fastp_adapter_detect.cwl
@@ -8,10 +8,11 @@ doc: |
   Processes up to 1M reads by default. --detect_adapter_for_pe is added
   automatically when reads2 is provided.
   Manual adapters override detected adapters independently for each read end.
-  Detected adapters are selected for cutadapt only when fastp reports at least
-  1% adapter-trimmed bases and each detected sequence starts with a standard
-  Illumina adapter seed: AGATCGGA (TruSeq) or CTGTCTCT (Nextera). Cutadapt runs
-  when at least one read end has a manual or validated detected adapter.
+  Detected adapters are selected for cutadapt only when fastp annotates the exact
+  sequence as a member of its built-in known-adapter pool. Fastp's less-than-1%
+  adapter-content warning is informational and does not reject a known adapter.
+  De novo or unspecified detections are rejected. Cutadapt runs when at least
+  one read end has a manual or known detected adapter.
   In fastp, a single-end report omits the entire
   adapter_cutting section when no adapter is detected. Paired-end reports retain
   the section and report "unspecified" for an end where no adapter is detected.
@@ -87,26 +88,21 @@ arguments:
     valueFrom: >-
       && detected_r1=\$(sed -n 's/.*"read1_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json)
       && detected_r2=\$(sed -n 's/.*"read2_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json)
-      && adapter_trimmed_bases=\$(awk '/"adapter_trimmed_bases"/ {gsub(/[^0-9]/, "", $0); print; exit}' $(inputs.sample_name).fastp.json)
-      && total_bases=\$(awk '/"before_filtering"/ {in_before=1} in_before && /"total_bases"/ {gsub(/[^0-9]/, "", $0); print; exit}' $(inputs.sample_name).fastp.json)
-      && adapter_pct=\$(awk -v trimmed="$adapter_trimmed_bases" -v total="$total_bases" 'BEGIN {if (total > 0) printf "%.6f", 100 * trimmed / total; else print "0"}')
       && manual_r1='$(inputs.manual_r1_adapter ? inputs.manual_r1_adapter : "")'
       && manual_r2='$(inputs.manual_r2_adapter ? inputs.manual_r2_adapter : "")'
       && manual_r1=\$(printf '%s' "$manual_r1" | awk '{$1=$1; print}')
       && manual_r2=\$(printf '%s' "$manual_r2" | awk '{$1=$1; print}')
       && if [ "\$(printf '%s' "$manual_r1" | tr '[:upper:]' '[:lower:]')" = "unspecified" ]; then manual_r1=""; fi
       && if [ "\$(printf '%s' "$manual_r2" | tr '[:upper:]' '[:lower:]')" = "unspecified" ]; then manual_r2=""; fi
-      && adapter_pct_ok=false
-      && detected_r1_ok=false
-      && detected_r2_ok=false
-      && if awk -v pct="$adapter_pct" 'BEGIN {exit pct < 1.0}'; then adapter_pct_ok=true; fi
-      && if printf '%s' "$detected_r1" | grep -qE '^(AGATCGGA|CTGTCTCT)'; then detected_r1_ok=true; fi
-      && if [ -n "$(inputs.reads2 != null ? "paired" : "")" ] && printf '%s' "$detected_r2" | grep -qE '^(AGATCGGA|CTGTCTCT)'; then detected_r2_ok=true; fi
+      && detected_r1_known=false
+      && detected_r2_known=false
+      && if [ -n "$detected_r1" ] && grep -Fq "$detected_r1 ->" '$(inputs.sample_name).fastp.html'; then detected_r1_known=true; fi
+      && if [ -n "$(inputs.reads2 != null ? "paired" : "")" ] && [ -n "$detected_r2" ] && grep -Fq "$detected_r2 ->" '$(inputs.sample_name).fastp.html'; then detected_r2_known=true; fi
       && : > r1_adapter.txt
       && : > r2_adapter.txt
       && printf 'false\n' > run_cutadapt.txt
-      && if [ -n "$manual_r1" ]; then printf '%s\n' "$manual_r1" > r1_adapter.txt; elif [ "$adapter_pct_ok" = true ] && [ "$detected_r1_ok" = true ]; then printf '%s\n' "$detected_r1" > r1_adapter.txt; fi
-      && if [ -n "$(inputs.reads2 != null ? "paired" : "")" ]; then if [ -n "$manual_r2" ]; then printf '%s\n' "$manual_r2" > r2_adapter.txt; elif [ "$adapter_pct_ok" = true ] && [ "$detected_r2_ok" = true ]; then printf '%s\n' "$detected_r2" > r2_adapter.txt; fi; fi
+      && if [ -n "$manual_r1" ]; then printf '%s\n' "$manual_r1" > r1_adapter.txt; elif [ "$detected_r1_known" = true ]; then printf '%s\n' "$detected_r1" > r1_adapter.txt; fi
+      && if [ -n "$(inputs.reads2 != null ? "paired" : "")" ]; then if [ -n "$manual_r2" ]; then printf '%s\n' "$manual_r2" > r2_adapter.txt; elif [ "$detected_r2_known" = true ]; then printf '%s\n' "$detected_r2" > r2_adapter.txt; fi; fi
       && if [ -s r1_adapter.txt ] || [ -s r2_adapter.txt ]; then printf 'true\n' > run_cutadapt.txt; fi
 
 outputs:

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -133,10 +133,11 @@ doc: |
   - `quality_cutoff`: Quality trim cutoff, see https://cutadapt.readthedocs.io/en/v3.4/guide.html#quality-trimming for how 5' 3' is handled
 
   Manual adapters override fastp detection independently for each read end.
-  Each detected adapter is selected independently when fastp reports at least 1%
-  adapter-trimmed bases and its sequence starts with an Illumina seed (AGATCGGA or
-  CTGTCTCT). Cutadapt runs when either adapter is selected, using -a for R1 and -A
-  for R2. If neither adapter is selected, cutadapt is skipped.
+  Each detected adapter is selected independently only when fastp identifies its
+  exact sequence in the built-in known-adapter pool. Fastp's less-than-1% warning
+  is informational and does not reject a known adapter. De novo and unspecified
+  detections are rejected. Cutadapt runs when either adapter is selected, using
+  -a for R1 and -A for R2. If neither adapter is selected, cutadapt is skipped.
 
   At this time the workflow only accepts a single input for these options. If you
   have multiple read groups with unique trimming needs, we recommend pre-trimming

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -881,5 +881,5 @@ hints:
 - SE
 - STAR
 "sbg:links":
-- id: 'https://github.com/childrens-bti/kf-rnaseq-workflow-cnh/releases/tag/v1.2.3'
+- id: 'https://github.com/childrens-bti/kf-rnaseq-workflow-cnh/releases/tag/v1.2.4'
   label: github-release


### PR DESCRIPTION
## Description
This PR closes #27 
Refine the fastp adapter safeguard so the less-than-1% adapter-content warning is informational rather than a hard gate.

Fastp 1.3.6 checks its built-in known-adapter pool before falling back to de novo detection. The workflow now uses fastp's HTML annotation (sequence -> adapter description) to determine whether the exact detected sequence belongs to that pool:

- Known-pool adapter: pass it to Cutadapt regardless of adapter percentage.
- De novo or unrecognized sequence: skip Cutadapt.
- No detected adapter: skip Cutadapt.
- Manual adapter: continue to override automatic detection.

This prevents low-abundance known adapters, including the observed 0.926% Illumina TruSeq adapter, from being rejected while retaining protection against biological sequences misidentified by de novo detection.

- Testing
https://cavatica.sbgenomics.com/u/childrens-bti/cruz-itt-1068-rna/tasks/81cf99b7-acb4-4ba0-95ef-e725667f8efe/

